### PR TITLE
remove hardcoded CA_DIR from RecordIO

### DIFF
--- a/SpaceMon/RecordIO.pm
+++ b/SpaceMon/RecordIO.pm
@@ -134,7 +134,6 @@ sub uploadRecord{
       VERBOSE => $self->{'VERBOSE'},
       DEBUG   => $self->{'DEBUG'},
       URL     => $self->{'DATASVC'},
-      CA_DIR  => '/etc/grid-security/certificates',
       FORMAT  => 'perl',
       );
   my ($response,$content,$target);


### PR DESCRIPTION
CA_DIR hardcoded in RecordIO prevents UserAgent from finding CA_DIR	 via the X509_CERT_DIR environment variable. The default CA_DIR value defined on line 18 already includes '/etc/grid-security/certificates':
https://github.com/pavel-demin/DMWMMON/blob/master/SpaceMon/UserAgent.pm#L18

This patch would also solve the issue https://github.com/dmwm/DMWMMON/issues/12